### PR TITLE
Update github-actions.yml

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -54,9 +54,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check License Header
-        uses: apache/skywalking-eyes@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
We have a dedicate GitHub actions for header check so this should be updated, and we don't recommend using `@main` so there is no unexpected behaviors when we have changes in our codebase.

See https://github.com/apache/skywalking-eyes/pull/123